### PR TITLE
feat: prevent medic AI from dismounting themselves

### DIFF
--- a/Apex_framework.terrain/code/functions/fn_clientAIBehaviours.sqf
+++ b/Apex_framework.terrain/code/functions/fn_clientAIBehaviours.sqf
@@ -165,7 +165,7 @@ for '_x' from 0 to 1 step 0 do {
 														((assignedVehicleRole _entity) isNotEqualTo []) && 
 														{(((assignedVehicleRole _entity) # 0) isEqualTo 'cargo')}
 													) then {
-														moveOut _entity;
+														// moveOut _entity; // auto-dismount medic AI
 													};
 												};
 											};


### PR DESCRIPTION
Resolves the following Discord thread:
https://canary.discord.com/channels/1069012076644798534/1499922304816250950
> Upon recruiting Medic AI near gitmo they will rarely obey SL instructions. If SL is able to get AI into vehicles AI will dismount immediately if they see an injured player nearby, this will continue until the Medic AI is not near an injured player via healing them or distance. If player commands AI to mount into vehicle again the AI will immediately dismount to find injured player.