### PR TITLE
fix: don't allow taking recruits from other players

### DIFF
--- a/Apex_framework.terrain/code/functions/fn_clientCore.sqf
+++ b/Apex_framework.terrain/code/functions/fn_clientCore.sqf
@@ -2362,7 +2362,10 @@ for '_z' from 0 to 1 step 0 do {
 				{((group _cursorTarget) isNotEqualTo (group _QS_player))} &&
 				{((side (group _cursorTarget)) isEqualTo (side (group _QS_player)))} &&
 				{(_cursorTarget getVariable ['QS_RD_recruitable',_false])} &&
-				{!isPlayer leader _cursorTarget} && // Prevent stealing recruits from other players
+				{ // Prevent stealing recruits from other players
+					!isPlayer leader _cursorTarget
+					&& {!(_cursorTarget getVariable ['TGC_recruit_owner',objNull] in units _cursorTarget)}
+				} &&
 				{(isNull (attachedTo _cursorTarget))}
 			) then {
 				if (!(_QS_interaction_recruit)) then {

--- a/Apex_framework.terrain/code/functions/fn_clientCore.sqf
+++ b/Apex_framework.terrain/code/functions/fn_clientCore.sqf
@@ -2362,6 +2362,10 @@ for '_z' from 0 to 1 step 0 do {
 				{((group _cursorTarget) isNotEqualTo (group _QS_player))} &&
 				{((side (group _cursorTarget)) isEqualTo (side (group _QS_player)))} &&
 				{(_cursorTarget getVariable ['QS_RD_recruitable',_false])} &&
+				{ // Prevent stealing recruits from player leaders
+					_cursorTarget getVariable ['QS_unit_isRecruited',_false] isNotEqualTo _true
+					|| {!isPlayer leader _cursorTarget}
+				} &&
 				{(isNull (attachedTo _cursorTarget))}
 			) then {
 				if (!(_QS_interaction_recruit)) then {

--- a/Apex_framework.terrain/code/functions/fn_clientCore.sqf
+++ b/Apex_framework.terrain/code/functions/fn_clientCore.sqf
@@ -2362,10 +2362,7 @@ for '_z' from 0 to 1 step 0 do {
 				{((group _cursorTarget) isNotEqualTo (group _QS_player))} &&
 				{((side (group _cursorTarget)) isEqualTo (side (group _QS_player)))} &&
 				{(_cursorTarget getVariable ['QS_RD_recruitable',_false])} &&
-				{ // Prevent stealing recruits from player leaders
-					_cursorTarget getVariable ['QS_unit_isRecruited',_false] isNotEqualTo _true
-					|| {!isPlayer leader _cursorTarget}
-				} &&
+				{!isPlayer leader _cursorTarget} && // Prevent stealing recruits from other players
 				{(isNull (attachedTo _cursorTarget))}
 			) then {
 				if (!(_QS_interaction_recruit)) then {

--- a/Apex_framework.terrain/code/functions/fn_clientInteractRecruit.sqf
+++ b/Apex_framework.terrain/code/functions/fn_clientInteractRecruit.sqf
@@ -75,6 +75,7 @@ _t enableAIFeature ['COVER',FALSE];
 (group _t) setSpeedMode 'FULL';
 [_t] call (missionNamespace getVariable 'QS_fnc_clientArsenal');
 _t setVariable ['QS_unit_isRecruited',TRUE,TRUE];
+_t setVariable ['TGC_recruit_owner',player,TRUE];
 _t addEventHandler [
 	'HandleDamage',
 	{


### PR DESCRIPTION
This prevents player leaders from taking AI recruits already assigned to another player leader.