### PR TITLE
Fixed Load Disallowed Bug

### DIFF
--- a/Apex_framework.terrain/code/functions/fn_vSetup.sqf
+++ b/Apex_framework.terrain/code/functions/fn_vSetup.sqf
@@ -18,6 +18,9 @@ _t = typeOf _u;
 _t2 = toLowerANSI _t;
 _isSimpleObject = isSimpleObject _u;
 _u setVariable ['QS_vehicle',TRUE,(!isDedicated)];
+if (_t2 in ['b_supplycrate_f','b_cargonet_01_ammo_f']) then {
+	_u setVariable ['QS_logistics',TRUE,TRUE];
+};
 if (_t2 isKindOf 'Heli_Light_01_base_F') then {
 	for '_i' from 0 to 9 do {_u setObjectTextureGlobal [_i,'#(argb,8,8,3)color(0,0,0,0.6)'];};
 };


### PR DESCRIPTION
Loading mission spawned supply boxes and cargo nets was missing the "QS_logistics" variable on creation, causing players to receive a "Load Disallowed" message when trying to load either object into a vehicle such as a cargo van.