### PR TITLE
Fix: Non-Sniper Enemies Proning

### DIFF
--- a/Apex_framework.terrain/code/functions/fn_AIHandleUnit.sqf
+++ b/Apex_framework.terrain/code/functions/fn_AIHandleUnit.sqf
@@ -35,6 +35,20 @@ if (
 };
 private _grp = group _unit;
 _objectParent = objectParent _unit;
+
+// Keep non-sniper enemy infantry standing. This is enforced by
+// the recurring AI handler because other mission behaviors can restore AUTO or
+// explicitly select DOWN after the unit's initial setup.
+private _unitType = toLowerANSI (typeOf _unit);
+if (
+	(isNull _objectParent) &&
+	{(!isPlayer _unit)} &&
+	{((side _unit) in [EAST,RESISTANCE])} &&
+	{(_unit isKindOf 'CAManBase')} &&
+	{(!((_unitType select [0,8]) in ['o_sniper','i_sniper']))}
+) then {
+	_unit setUnitPos 'Up';
+};
 if (!(_unit getVariable ['QS_AI_UNIT',FALSE])) then {
 	_unit setVariable ['QS_AI_UNIT',TRUE,FALSE];
 	_unit setVariable ['QS_AI_UNIT_rv',[(random 1),(random 1),(random 1)],FALSE];

--- a/Apex_framework.terrain/code/functions/fn_unitSetup.sqf
+++ b/Apex_framework.terrain/code/functions/fn_unitSetup.sqf
@@ -14,6 +14,17 @@ Description:
 ______________________________________________________/*/
 
 _unit = _this;
+_unitType = toLowerANSI (typeOf _unit);
+
+// Hold non-sniper enemy infantry in a standing stance from initial setup.
+if (
+	(!isPlayer _unit) &&
+	{((side _unit) in [EAST,RESISTANCE])} &&
+	{(_unit isKindOf 'CAManBase')} &&
+	{(!((_unitType select [0,8]) in ['o_sniper','i_sniper']))}
+) then {
+	_unit setUnitPos 'Up';
+};
 if (
 	(!(missionNamespace getVariable ['QS_missionConfig_enemyRandGear',TRUE])) ||
 	{((missionNamespace getVariable ['QS_system_activeDLC','']) isNotEqualTo '')} ||
@@ -23,7 +34,6 @@ if (
 	_unit
 };
 _unit = _this;
-_unitType = toLowerANSI (typeOf _unit);
 private _weapons = [];
 private _optics = [];
 private _backpacks = [];


### PR DESCRIPTION
Non-snipers should not be in the prone position. They should now remain standing at all times.